### PR TITLE
Ensure "org-protocol:/capture:/..." consistency

### DIFF
--- a/capture.js
+++ b/capture.js
@@ -3,7 +3,7 @@ var capture = function(){
     var esc = function (text) { return replace_all(replace_all(replace_all(encodeURIComponent(text),"[(]",escape("(")),"[)]",escape(")")),"[']",escape("'")); };
     var selection = window.getSelection().toString();
 
-    var uri = 'org-protocol://';
+    var uri = 'org-protocol:/';
     if (selection != "")
     {
 	uri += 'capture:/p/';


### PR DESCRIPTION
It seems that "org-protocol://capture:/L/..." does not work properly on
my setup (Linux/KDE) which leads to Emacs opening a server buffer to a
new "~/org/.../org-protocol://" file.  Testing with

`xdg-open org-protocol:/capture/L/http://some.link.out.there`

Leads to the expected result of opening a capture template and filling
in the details, so change capture.js to just use that kind of link.

http://orgmode.org/worg/org-contrib/org-protocol.html seems to show the
same as well, using either "org-protocol://sub-protocol://" (2 slashes)
or "org-protocol:/sub-protocol:/" (1 slash), but not
"org-protocol://sub-protocol:/".