### PR TITLE
Add Windows protocol-handler-setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,15 @@ and restart the desktop. You can also download [EmacsClient.app.zip], which I pr
 
 #### Under Windows
 
-See instructions on [Org-Mode site], and contribute them here with a pull request :-).
+Open the Registry Editor (Win-R, then type `regedit`). Within `HKEY_CLASSES_ROOT`, add a key called `org-protocol`. Within `org-protocol`, set the data for the string value with the name `(Default)`  to be `URL:org-protocol`, add another string value with name `URL Protocol` and no data, and add a key called `shell`.
+
+Within `shell`, create a key called `open`.
+
+Within `open`, create a key called `command`.
+
+Within `command`, set the data for the string value with the name `(Default)` to `"C:\the\path\to\your\emacsclientw.exe" "%1"`, updating the path to point to your Emacs installation.
+
+If you get stuck, see [this guide to registering a protocol handler](https://msdn.microsoft.com/en-us/library/aa767914\(v=vs.85\).aspx) and look at how registries are set up for other protocol handlers (`skype`, `ftp`, etc.). Most of your pre-existing protocol handlers have more config than you need.
 
 ### Set up handlers in emacs
 


### PR DESCRIPTION
Hi there!

I'm not knowledgeable about Windows at all, but with a bunch of Googling I managed to get this extension working. I've added some instructions to the README reflecting what I did.

Given my ignorance, I worry I might be misusing terms here: as far as I can tell, within the Windows Registry Editor, a "key" is a list of key-value pairs, a "value" is a key-value pair, a "name" is a key, and "data" is a value, but I'd appreciate it if someone who knows something about Windows registries could confirm that I'm using these terms right.