### PR TITLE
fix URL handling when using xdg-open

### DIFF
--- a/capture.js
+++ b/capture.js
@@ -3,7 +3,7 @@ var capture = function(){
     var esc = function (text) { return replace_all(replace_all(replace_all(encodeURIComponent(text),"[(]",escape("(")),"[)]",escape(")")),"[']",escape("'")); };
     var selection = window.getSelection().toString();
 
-    var uri = 'org-protocol://';
+    var uri = 'org-protocol:///';
     if (selection != "")
     {
 	uri += 'capture:/p/';


### PR DESCRIPTION
using two `/` leads to the second `:` being eaten by xdg-open

fixes #16