### PR TITLE
Use new org-protocol link style

### DIFF
--- a/capture.js
+++ b/capture.js
@@ -3,20 +3,20 @@ var capture = function(){
     var esc = function (text) { return replace_all(replace_all(replace_all(encodeURIComponent(text),"[(]",escape("(")),"[)]",escape(")")),"[']",escape("'")); };
     var selection = window.getSelection().toString();
 
-    var uri = 'org-protocol://';
+    var uri = 'org-protocol://capture?';
     if (selection != "")
     {
-	uri += 'capture:/p/';
+	uri += 'template=p';
     }
     else
     {
-	uri += 'capture:/L/'
+	uri += 'template=L'
     };
 
-    uri += encodeURIComponent(location.href) + '/' +
+    uri += "&url=" + encodeURIComponent(location.href) + '&title=' +
 	esc(document.title) ;
 
-    if (selection != "") { uri += '/' + esc(selection); };
+    if (selection != "") { uri += '&body=' + esc(selection); };
 
     console.log("Capturing the following URI with org-protocol:", uri);
 


### PR DESCRIPTION
Not sure if you want this or not, but it does stop org version >= 9 from issuing a warning each time the extension captures something.