### PR TITLE
Adopt for org-mode version 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,29 @@ Detailed instructions available at [Org-Mode site].
 
 The gist of it is to make your system recognize emacsclient as the handler of ```org-protocol://``` links. In addition, one needs to set up emacs to load org-protocol and to set up capture templates.
 
+### Modify xdg-open behavior under Linux
+
+```bash
+sudo dnf install pcre-tools # Fedora
+sudo apt install pcregrep   # Debian/Ubuntu
+sudo pacman -S pcre         # Arch
+```
+
+```bash
+sudo mv -iv /usr/bin/xdg-open /usr/bin/system-xdg-open
+sudoedit /usr/bin/xdg-open # Paste a wrapper
+#!/bin/bash
+XDG_OPEN='/usr/bin/system-xdg-open'
+EMACS_CLIENT='/usr/bin/emacsclient'
+
+if echo "$1" | pcregrep -q '^org-protocol?://'; then
+    "$EMACS_CLIENT" ${*}
+    exit 0
+else
+    $XDG_OPEN ${*}
+fi
+```
+
 ### Register emacsclient as the ```org-protocol``` handler
 
 #### Under Linux

--- a/capture.js
+++ b/capture.js
@@ -6,17 +6,17 @@ var capture = function(){
     var uri = 'org-protocol://';
     if (selection != "")
     {
-	uri += 'capture:/p/';
+	uri += 'capture?template=p';
     }
     else
     {
-	uri += 'capture:/L/'
+	uri += 'capture?template=L'
     };
 
-    uri += encodeURIComponent(location.href) + '/' +
+    uri += '&url=' + encodeURIComponent(location.href) + '&title=' +
 	esc(document.title) ;
 
-    if (selection != "") { uri += '/' + esc(selection); };
+    if (selection != "") { uri += '&body=' + esc(selection); };
 
     console.log("Capturing the following URI with org-protocol:", uri);
 


### PR DESCRIPTION
Source: http://orgmode.org/Changes.html
New org-protocol key=value syntax
Org-protocol can now handle query-style parameters such as:
org-protocol://store-link?url=http:%2F%2Flocalhost%2Findex.html&title=The%20title
org-protocol://capture?template=x&title=Hello&body=World&url=http:%2F%2Fexample.com

Also we need a xdg-open wrapper because xdg-open modifies URL. It adds
`?` after `capture`.

Original xdg-open:
org-protocol://capture/?template=p&url=https%3A%2F%2Fgithub.com%2Fsprig%2Forg-capture-extension&title=sprig%2Forg-capture-extension%3A%20A%20Chrome%20and%20firefox%20extension%20facilitating%20org-capture%20in%20emacs

Wrapper xdg-open:
org-protocol://capture?template=l&url=https%3A%2F%2Fgithub.com%2Fsprig%2Forg-capture-extension&title=sprig%2Forg-capture-extension%3A%20A%20Chrome%20and%20firefox%20extension%20facilitating%20org-capture%20in%20emacs