### PR TITLE
Make keyboard shortcut activate addon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
   },
 
   "commands": {
-    "org-capture": {
+    "_execute_browser_action": {
       "description": "Capture current page with org-capture",
       "suggested_key": {
         "default": "Ctrl+Shift+L",


### PR DESCRIPTION
The add-on defined a shortcut to activate the "org-capture" command but wasn't listening for it anywhere. Changing it to _execute_browser_action makes it act as if a user had clicked the BrowserAction icon without any additional code.

I also submitted a PR to the cask folks to include your example EmacsClient.app as an app installable through brew cask; that was accepted yesterday, and there is a separate PR, #44 to update the README with instructions for installing that via brew cask