### PR TITLE
Capture with note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Org Capture Extension
 
-This is an extension for Google Chrome (tm) and Firefox (tm) which adds a "Capture" button, sending the site address, title, and selected text (if any) to emacs via org-protocol, see the [Org-Mode site] for instructions for setting that up org-protocol. The extentsion itself is available at the [Chrome App Store].
+This is an extension for Google Chrome (tm) and Firefox (tm) which adds a "Capture" button, sending the site address, title, and selected text (if any) to emacs via org-protocol, see the [Org-Mode site] for instructions for setting that up org-protocol. You can also bind a hotkey to add a custom note.
+
+The extentsion itself is available at the [Chrome App Store].
 
 # Improvements
 

--- a/background.js
+++ b/background.js
@@ -42,6 +42,24 @@ chrome.runtime.onInstalled.addListener(function (details) {
       });
 });
 
+function executeCapture(tab, with_note) {
+    chrome.tabs.executeScript(tab.id, {
+        code: 'var capture_with_note = ' + String(with_note) + ';'
+    }, function() {
+        chrome.tabs.executeScript(tab.id, {file: "capture.js"});
+    });
+}
+
 chrome.browserAction.onClicked.addListener(function (tab) {
-  chrome.tabs.executeScript({file: "capture.js"});
+    executeCapture(tab, false);
 });
+
+chrome.commands.onCommand.addListener(function(command) {
+    if (command === 'capture-with-note') {
+        chrome.tabs.query({currentWindow: true, active: true }, function (tabs) {
+            const current = tabs[0];
+            executeCapture(current, true);
+        });
+    }
+});
+

--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,13 @@
         "default": "Ctrl+Shift+L",
         "mac": "Command+Shift+L"
       }
+    },
+    "capture-with-note": {
+      "description": "Prompt for note and capture",
+      "suggested_key": {
+        "default": "Ctrl+Shift+Y",
+        "mac": "Command+Shift+Y"
+      }
     }
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -15,9 +15,7 @@
   "options_ui": {
     "page": "options.html"
   },
-
   "browser_action": {
-    "default_icon": "org-mode-unicorn.png"
   },
 
   "commands": {


### PR DESCRIPTION
This is a feature I lacked for a while. TLDR:
![image](https://user-images.githubusercontent.com/291333/49182793-1c740200-f353-11e8-82a3-8f4504835ea4.png)

When you press `Ctrl-Shif-Y`, you will get prompted for additional note which will be captured in same way selected text can be captured. I've made sure the previous behaviour still works and all the combinations (e.g. capture selected text, then 'normal' capture, then capture with note etc..).

I had to delete default_icon in first commit since the icon is missing and it caused extension crashing...