### PR TITLE
doc: fix unescaped [, ] chars + fix lambda syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ _Hint:_ You can put code in capture handlers via %() blocks. I use this mechanis
 (defun transform-square-brackets-to-round-ones(string-to-transform)
   "Transforms [ into ( and ] into ), other chars left unchanged."
   (concat 
-  (mapcar #'(lambda (c) (if (equal c ?[) ?\( (if (equal c ?]) ?\) c))) string-to-transform))
+  (mapcar (lambda (c) (if (equal c ?\[) ?\( (if (equal c ?\]) ?\) c))) string-to-transform))
   )
 
 (setq org-capture-templates `(


### PR DESCRIPTION
I forgot to escape [, ] chars in my code snippet to import ArXiv url.
This causes Emacs warnings, see: 
https://www.reddit.com/r/emacs/comments/bisiwa/unescaped_character_literals_detected/
This patch fixes this problem.