### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ _Hint:_ You can put code in capture handlers via %() blocks. I use this mechanis
 (defun transform-square-brackets-to-round-ones(string-to-transform)
   "Transforms [ into ( and ] into ), other chars left unchanged."
   (concat 
-  (mapcar #'(lambda (c) (if (equal c ?[) ?\( (if (equal c ?]) ?\) c))) string-to-transform))
+  (mapcar #'(lambda (c) (if (equal c ?\[) ?\( (if (equal c ?\]) ?\) c))) string-to-transform))
   )
 
 (setq org-capture-templates `(


### PR DESCRIPTION
Fixed placeholder notation in `transform-square-brackets-to-round-ones`: All four have to be escaped on my system (Emacs 27.1, Debian).